### PR TITLE
Fixed duplicate song name in status bar after GMusic: Restart

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -34,6 +34,7 @@ export function activate(context: ExtensionContext) {
             });
         })
     let restartCommand = commands.registerCommand('gmusic.restart', () => {
+        gMusic.dispose();
         gMusic = new gMusicClass(context);
     })
 
@@ -64,7 +65,7 @@ interface rating {
 
 /**
  * Constantly changing class that holds GPMDP data
- * 
+ *
  * @export
  * @class gMusicData
  */
@@ -81,7 +82,7 @@ export class gMusicClass {
 
     constructor(context: ExtensionContext) {
         const Cache = require('vscode-cache');
-        
+
         // Create as needed
         if (!this._statusBarItem) {
             this._statusBarItem = window.createStatusBarItem(StatusBarAlignment.Left);


### PR DESCRIPTION
Fixes #2

**Explanation of fix**
`gMusic` is now disposed of on restart.  This causes `dispose` to be called on the status bar item, which ensures that the new one created in the `gMusicClass` constructor isn't a duplicate.

Tested the changes locally on my Mac to verify it works.
